### PR TITLE
Kompaktiblität mit HUGO 0.69+

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -11,6 +11,12 @@ enableEmoji = true
 enableRobotsTXT = true
 enableMissingTranslationPlaceholders = true
 
+[markup]
+  defaultMarkdownHandler = "goldmark"
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
+
 [params]
     title = "junghacker"
     date = "2019-07-13"


### PR DESCRIPTION
Unterstützung für Inline HTML für HUGO 0.69+ aktiviert.